### PR TITLE
drop x_shift and y_shift from featurevis

### DIFF
--- a/Examples.ipynb
+++ b/Examples.ipynb
@@ -37,21 +37,23 @@
      "output_type": "stream",
      "text": [
       "Connecting ecobost@at-database.ad.bcm.edu:3306\n",
-      "04-09-2019:20:15:43 INFO     configs.py           224:\t Ignoring input arguments: \"\"when creating datasets\n",
-      "04-09-2019:20:15:43 INFO     configs.py           203:\t Loading None dataset with tier=None\n",
-      "04-09-2019:20:15:43 INFO     data_schemas.py      977:\t Fetching data for {'data_hash': '7572eed73113c993e7d1b92f83e270b4', 'group_id': 29, 'net_hash': '80d0d4bc112470b2ba04cd5eba048e39', 'neuron_id': 119, 'readout_key': 'group029-21067-9-17-0', 'data_description': \"V1 L2/3 on stimulus.Frame. normalize=True on all (except '')\", 'stats_source': 'all', 'normalize': 1, 'normalize_per_image': 0, 'layer': 'L2/3', 'brain_area': 'V1'}\n",
-      "04-09-2019:20:15:43 INFO     data_schemas.py      987:\t Data will be (images,behavior,pupil_center,responses)\n",
-      "04-09-2019:20:15:43 INFO     data_schemas.py      990:\t Loading dataset group029-21067-9-17-0 --> /external/cache/static21067-9-17-preproc0.h5\n",
-      "04-09-2019:20:15:43 INFO     configs.py           208:\t Adding stats_source \"all\" to dataset\n",
-      "04-09-2019:20:15:43 INFO     configs.py           211:\t Using statistics source all\n",
-      "04-09-2019:20:15:43 INFO     configs.py            85:\t Excluding \"\" from normalization\n"
+      "25-09-2019:16:34:52 INFO     configs.py           224:\t Ignoring input arguments: \"\"when creating datasets\n",
+      "25-09-2019:16:34:52 INFO     configs.py           203:\t Loading None dataset with tier=None\n",
+      "25-09-2019:16:34:52 INFO     data_schemas.py     1052:\t Fetching data for {'data_hash': '7572eed73113c993e7d1b92f83e270b4', 'group_id': 29, 'net_hash': '80d0d4bc112470b2ba04cd5eba048e39', 'neuron_id': 119, 'readout_key': 'group029-21067-9-17-0', 'data_description': \"V1 L2/3 on stimulus.Frame. normalize=True on all (except '')\", 'stats_source': 'all', 'normalize': 1, 'normalize_per_image': 0, 'layer': 'L2/3', 'brain_area': 'V1'}\n",
+      "25-09-2019:16:34:52 INFO     data_schemas.py     1062:\t Data will be (images,behavior,pupil_center,responses)\n",
+      "25-09-2019:16:34:52 INFO     data_schemas.py     1065:\t Loading dataset group029-21067-9-17-0 --> /external/cache/static21067-9-17-preproc0.h5\n",
+      "25-09-2019:16:34:52 INFO     configs.py           208:\t Adding stats_source \"all\" to dataset\n",
+      "25-09-2019:16:34:52 INFO     configs.py           211:\t Using statistics source all\n",
+      "25-09-2019:16:34:52 INFO     configs.py            85:\t Excluding \"\" from normalization\n",
+      "25-09-2019:16:34:52 INFO     configs.py           177:\t Using stimulus.Frame as stimulus type for all datasets\n",
+      "25-09-2019:16:34:52 INFO     configs.py           180:\t Stimulus sources: \"stimulus.Frame\"\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/src/static-networks/staticnet_analyses/multi_mei.py:1834: UserWarning: Use of this table is deprecated. It is kept only for record keeping purpose\n",
+      "/src/static-networks/staticnet_analyses/multi_mei.py:1649: UserWarning: Use of this table is deprecated. It is kept only for record keeping purpose\n",
       "  warnings.warn('Use of this table is deprecated. It is kept only for record keeping purpose')\n",
       "/usr/local/lib/python3.6/dist-packages/h5py/_hl/dataset.py:313: H5pyDeprecationWarning: dataset.value has been deprecated. Use dataset[()] instead.\n",
       "  \"Use dataset[()] instead.\", H5pyDeprecationWarning)\n"
@@ -61,40 +63,38 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "04-09-2019:20:15:43 INFO     configs.py           177:\t Using stimulus.Frame as stimulus type for all datasets\n",
-      "04-09-2019:20:15:43 INFO     configs.py           180:\t Stimulus sources: \"stimulus.Frame\"\n",
-      "04-09-2019:20:15:43 INFO     configs.py           114:\t Using all trial from stimulus.Frame\n",
-      "04-09-2019:20:15:43 INFO     configs.py           188:\t Selecting trials from stimulus.Frame and tier=None for dataset group029-21067-9-17-0\n",
-      "04-09-2019:20:15:43 INFO     configs.py           190:\t Found 5998 active trials\n",
-      "04-09-2019:20:15:43 INFO     configs.py           150:\t Loader sampler is SubsetSequentialSampler\n",
-      "04-09-2019:20:15:43 INFO     configs.py           152:\t Number of samples in the loader will be 5998\n",
-      "04-09-2019:20:15:43 INFO     configs.py           154:\t Number of batches in the loader will be 5998\n",
-      "04-09-2019:20:15:43 INFO     configs.py           233:\t Subsampling to layer L2/3 and area(s) \"V1\"\n",
-      "04-09-2019:20:15:43 INFO     configs.py           399:\t Setting cuda=False\n",
-      "04-09-2019:20:15:47 INFO     configs.py           224:\t Ignoring input arguments: \"net_hash\", \"core_hash\", \"ro_hash\", \"shift_hash\", \"mod_hash\", \"train_hash\", \"data_hash\", \"group_id\", \"seed\", \"train_type\", \"schedule\", \"max_epoch\"when creating datasets\n",
-      "04-09-2019:20:15:47 INFO     configs.py           203:\t Loading None dataset with tier=train\n",
-      "04-09-2019:20:15:47 INFO     data_schemas.py      977:\t Fetching data for {'net_hash': '80d0d4bc112470b2ba04cd5eba048e39', 'core_hash': '28bc2fa358337c5012278f899b5b6947', 'ro_hash': 'e4cd67efe5a543b044cf8a74e440775e', 'shift_hash': '05c69a4aeaeea5e48fa8fc5e70181d67', 'mod_hash': 'a757e992ae449e3057ff1d512a51bd1e', 'train_hash': '2c25349fa0a81afbe907882e7b50a4da', 'data_hash': '7572eed73113c993e7d1b92f83e270b4', 'group_id': 29, 'seed': 1009, 'data_description': \"V1 L2/3 on stimulus.Frame. normalize=True on all (except '')\", 'stats_source': 'all', 'normalize': 1, 'normalize_per_image': 0, 'layer': 'L2/3', 'brain_area': 'V1'}\n",
-      "04-09-2019:20:15:47 INFO     data_schemas.py      987:\t Data will be (images,behavior,pupil_center,responses)\n",
-      "04-09-2019:20:15:47 INFO     data_schemas.py      990:\t Loading dataset group029-21067-9-17-0 --> /external/cache/static21067-9-17-preproc0.h5\n",
-      "04-09-2019:20:15:47 INFO     configs.py           208:\t Adding stats_source \"all\" to dataset\n",
-      "04-09-2019:20:15:47 INFO     configs.py           211:\t Using statistics source all\n",
-      "04-09-2019:20:15:47 INFO     configs.py            85:\t Excluding \"\" from normalization\n",
-      "04-09-2019:20:15:47 INFO     configs.py           177:\t Using stimulus.Frame as stimulus type for all datasets\n",
-      "04-09-2019:20:15:47 INFO     configs.py           180:\t Stimulus sources: \"stimulus.Frame\"\n",
-      "04-09-2019:20:15:47 INFO     configs.py           114:\t Using all trial from stimulus.Frame\n",
-      "04-09-2019:20:15:47 INFO     configs.py           188:\t Selecting trials from stimulus.Frame and tier=train for dataset group029-21067-9-17-0\n",
-      "04-09-2019:20:15:47 INFO     configs.py           190:\t Found 4475 active trials\n",
-      "04-09-2019:20:15:47 INFO     configs.py           150:\t Loader sampler is SubsetRandomSampler\n",
-      "04-09-2019:20:15:47 INFO     configs.py           152:\t Number of samples in the loader will be 4475\n",
-      "04-09-2019:20:15:47 INFO     configs.py           154:\t Number of batches in the loader will be 75\n",
-      "04-09-2019:20:15:47 INFO     configs.py           233:\t Subsampling to layer L2/3 and area(s) \"V1\"\n",
-      "04-09-2019:20:15:47 INFO     configs.py           399:\t Setting cuda=False\n",
-      "04-09-2019:20:15:47 INFO     cores.py              77:\t Ignoring input {'core_hash': '28bc2fa358337c5012278f899b5b6947'} when creating GaussianLaplaceCore\n",
-      "04-09-2019:20:15:47 INFO     readouts.py          140:\t Ignoring input {'ro_hash': 'e4cd67efe5a543b044cf8a74e440775e'} when creating SpatialTransformerPyramid2dReadout\n",
-      "04-09-2019:20:15:47 INFO     shifters.py           55:\t Ignoring input {'shift_hash': '05c69a4aeaeea5e48fa8fc5e70181d67'} when creating MLPShifter\n",
-      "04-09-2019:20:15:47 INFO     shifters.py           27:\t Ignoring input {} when creating MLP\n",
-      "04-09-2019:20:15:47 INFO     modulators.py         47:\t Ignoring input {'mod_hash': 'a757e992ae449e3057ff1d512a51bd1e'} when creating MLPModulator\n",
-      "04-09-2019:20:15:47 INFO     modulators.py         18:\t Ignoring input {} when creating MLP\n"
+      "25-09-2019:16:34:52 INFO     configs.py           114:\t Using all trial from stimulus.Frame\n",
+      "25-09-2019:16:34:52 INFO     configs.py           188:\t Selecting trials from stimulus.Frame and tier=None for dataset group029-21067-9-17-0\n",
+      "25-09-2019:16:34:52 INFO     configs.py           190:\t Found 5998 active trials\n",
+      "25-09-2019:16:34:52 INFO     configs.py           150:\t Loader sampler is SubsetSequentialSampler\n",
+      "25-09-2019:16:34:52 INFO     configs.py           152:\t Number of samples in the loader will be 5998\n",
+      "25-09-2019:16:34:52 INFO     configs.py           154:\t Number of batches in the loader will be 5998\n",
+      "25-09-2019:16:34:52 INFO     configs.py           233:\t Subsampling to layer L2/3 and area(s) \"V1\"\n",
+      "25-09-2019:16:34:52 INFO     configs.py           399:\t Setting cuda=False\n",
+      "25-09-2019:16:34:56 INFO     configs.py           224:\t Ignoring input arguments: \"net_hash\", \"core_hash\", \"ro_hash\", \"shift_hash\", \"mod_hash\", \"train_hash\", \"data_hash\", \"group_id\", \"seed\", \"train_type\", \"schedule\", \"max_epoch\"when creating datasets\n",
+      "25-09-2019:16:34:56 INFO     configs.py           203:\t Loading None dataset with tier=train\n",
+      "25-09-2019:16:34:56 INFO     data_schemas.py     1052:\t Fetching data for {'net_hash': '80d0d4bc112470b2ba04cd5eba048e39', 'core_hash': '28bc2fa358337c5012278f899b5b6947', 'ro_hash': 'e4cd67efe5a543b044cf8a74e440775e', 'shift_hash': '05c69a4aeaeea5e48fa8fc5e70181d67', 'mod_hash': 'a757e992ae449e3057ff1d512a51bd1e', 'train_hash': '2c25349fa0a81afbe907882e7b50a4da', 'data_hash': '7572eed73113c993e7d1b92f83e270b4', 'group_id': 29, 'seed': 1009, 'data_description': \"V1 L2/3 on stimulus.Frame. normalize=True on all (except '')\", 'stats_source': 'all', 'normalize': 1, 'normalize_per_image': 0, 'layer': 'L2/3', 'brain_area': 'V1'}\n",
+      "25-09-2019:16:34:56 INFO     data_schemas.py     1062:\t Data will be (images,behavior,pupil_center,responses)\n",
+      "25-09-2019:16:34:56 INFO     data_schemas.py     1065:\t Loading dataset group029-21067-9-17-0 --> /external/cache/static21067-9-17-preproc0.h5\n",
+      "25-09-2019:16:34:56 INFO     configs.py           208:\t Adding stats_source \"all\" to dataset\n",
+      "25-09-2019:16:34:56 INFO     configs.py           211:\t Using statistics source all\n",
+      "25-09-2019:16:34:56 INFO     configs.py            85:\t Excluding \"\" from normalization\n",
+      "25-09-2019:16:34:56 INFO     configs.py           177:\t Using stimulus.Frame as stimulus type for all datasets\n",
+      "25-09-2019:16:34:56 INFO     configs.py           180:\t Stimulus sources: \"stimulus.Frame\"\n",
+      "25-09-2019:16:34:56 INFO     configs.py           114:\t Using all trial from stimulus.Frame\n",
+      "25-09-2019:16:34:56 INFO     configs.py           188:\t Selecting trials from stimulus.Frame and tier=train for dataset group029-21067-9-17-0\n",
+      "25-09-2019:16:34:56 INFO     configs.py           190:\t Found 4475 active trials\n",
+      "25-09-2019:16:34:56 INFO     configs.py           150:\t Loader sampler is SubsetRandomSampler\n",
+      "25-09-2019:16:34:56 INFO     configs.py           152:\t Number of samples in the loader will be 4475\n",
+      "25-09-2019:16:34:56 INFO     configs.py           154:\t Number of batches in the loader will be 75\n",
+      "25-09-2019:16:34:56 INFO     configs.py           233:\t Subsampling to layer L2/3 and area(s) \"V1\"\n",
+      "25-09-2019:16:34:56 INFO     configs.py           399:\t Setting cuda=False\n",
+      "25-09-2019:16:34:56 INFO     cores.py              77:\t Ignoring input {'core_hash': '28bc2fa358337c5012278f899b5b6947'} when creating GaussianLaplaceCore\n",
+      "25-09-2019:16:34:56 INFO     readouts.py          140:\t Ignoring input {'ro_hash': 'e4cd67efe5a543b044cf8a74e440775e'} when creating SpatialTransformerPyramid2dReadout\n",
+      "25-09-2019:16:34:56 INFO     shifters.py           55:\t Ignoring input {'shift_hash': '05c69a4aeaeea5e48fa8fc5e70181d67'} when creating MLPShifter\n",
+      "25-09-2019:16:34:56 INFO     shifters.py           27:\t Ignoring input {} when creating MLP\n",
+      "25-09-2019:16:34:56 INFO     modulators.py         47:\t Ignoring input {'mod_hash': 'a757e992ae449e3057ff1d512a51bd1e'} when creating MLPModulator\n",
+      "25-09-2019:16:34:56 INFO     modulators.py         18:\t Ignoring input {} when creating MLP\n"
      ]
     },
     {
@@ -109,33 +109,33 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "04-09-2019:20:15:47 WARNING  models.py             82:\t Could not find paramater 'core.features.layer0.norm.num_batches_tracked' setting to initialization value\n",
-      "04-09-2019:20:15:47 WARNING  models.py             82:\t Could not find paramater 'core.features.layer1.norm.num_batches_tracked' setting to initialization value\n",
-      "04-09-2019:20:15:47 WARNING  models.py             82:\t Could not find paramater 'core.features.layer2.norm.num_batches_tracked' setting to initialization value\n",
-      "04-09-2019:20:15:47 INFO     configs.py           224:\t Ignoring input arguments: \"net_hash\", \"core_hash\", \"ro_hash\", \"shift_hash\", \"mod_hash\", \"train_hash\", \"data_hash\", \"group_id\", \"seed\", \"train_type\", \"schedule\", \"max_epoch\"when creating datasets\n",
-      "04-09-2019:20:15:47 INFO     configs.py           203:\t Loading None dataset with tier=train\n",
-      "04-09-2019:20:15:47 INFO     data_schemas.py      977:\t Fetching data for {'net_hash': '80d0d4bc112470b2ba04cd5eba048e39', 'core_hash': '28bc2fa358337c5012278f899b5b6947', 'ro_hash': 'e4cd67efe5a543b044cf8a74e440775e', 'shift_hash': '05c69a4aeaeea5e48fa8fc5e70181d67', 'mod_hash': 'a757e992ae449e3057ff1d512a51bd1e', 'train_hash': '2c25349fa0a81afbe907882e7b50a4da', 'data_hash': '7572eed73113c993e7d1b92f83e270b4', 'group_id': 29, 'seed': 1215, 'data_description': \"V1 L2/3 on stimulus.Frame. normalize=True on all (except '')\", 'stats_source': 'all', 'normalize': 1, 'normalize_per_image': 0, 'layer': 'L2/3', 'brain_area': 'V1'}\n",
-      "04-09-2019:20:15:47 INFO     data_schemas.py      987:\t Data will be (images,behavior,pupil_center,responses)\n",
-      "04-09-2019:20:15:47 INFO     data_schemas.py      990:\t Loading dataset group029-21067-9-17-0 --> /external/cache/static21067-9-17-preproc0.h5\n",
-      "04-09-2019:20:15:47 INFO     configs.py           208:\t Adding stats_source \"all\" to dataset\n",
-      "04-09-2019:20:15:47 INFO     configs.py           211:\t Using statistics source all\n",
-      "04-09-2019:20:15:47 INFO     configs.py            85:\t Excluding \"\" from normalization\n",
-      "04-09-2019:20:15:47 INFO     configs.py           177:\t Using stimulus.Frame as stimulus type for all datasets\n",
-      "04-09-2019:20:15:47 INFO     configs.py           180:\t Stimulus sources: \"stimulus.Frame\"\n",
-      "04-09-2019:20:15:47 INFO     configs.py           114:\t Using all trial from stimulus.Frame\n",
-      "04-09-2019:20:15:47 INFO     configs.py           188:\t Selecting trials from stimulus.Frame and tier=train for dataset group029-21067-9-17-0\n",
-      "04-09-2019:20:15:47 INFO     configs.py           190:\t Found 4475 active trials\n",
-      "04-09-2019:20:15:47 INFO     configs.py           150:\t Loader sampler is SubsetRandomSampler\n",
-      "04-09-2019:20:15:47 INFO     configs.py           152:\t Number of samples in the loader will be 4475\n",
-      "04-09-2019:20:15:47 INFO     configs.py           154:\t Number of batches in the loader will be 75\n",
-      "04-09-2019:20:15:47 INFO     configs.py           233:\t Subsampling to layer L2/3 and area(s) \"V1\"\n",
-      "04-09-2019:20:15:47 INFO     configs.py           399:\t Setting cuda=False\n",
-      "04-09-2019:20:15:47 INFO     cores.py              77:\t Ignoring input {'core_hash': '28bc2fa358337c5012278f899b5b6947'} when creating GaussianLaplaceCore\n",
-      "04-09-2019:20:15:47 INFO     readouts.py          140:\t Ignoring input {'ro_hash': 'e4cd67efe5a543b044cf8a74e440775e'} when creating SpatialTransformerPyramid2dReadout\n",
-      "04-09-2019:20:15:47 INFO     shifters.py           55:\t Ignoring input {'shift_hash': '05c69a4aeaeea5e48fa8fc5e70181d67'} when creating MLPShifter\n",
-      "04-09-2019:20:15:47 INFO     shifters.py           27:\t Ignoring input {} when creating MLP\n",
-      "04-09-2019:20:15:47 INFO     modulators.py         47:\t Ignoring input {'mod_hash': 'a757e992ae449e3057ff1d512a51bd1e'} when creating MLPModulator\n",
-      "04-09-2019:20:15:47 INFO     modulators.py         18:\t Ignoring input {} when creating MLP\n"
+      "25-09-2019:16:34:56 WARNING  models.py             82:\t Could not find paramater 'core.features.layer2.norm.num_batches_tracked' setting to initialization value\n",
+      "25-09-2019:16:34:56 WARNING  models.py             82:\t Could not find paramater 'core.features.layer0.norm.num_batches_tracked' setting to initialization value\n",
+      "25-09-2019:16:34:56 WARNING  models.py             82:\t Could not find paramater 'core.features.layer1.norm.num_batches_tracked' setting to initialization value\n",
+      "25-09-2019:16:34:57 INFO     configs.py           224:\t Ignoring input arguments: \"net_hash\", \"core_hash\", \"ro_hash\", \"shift_hash\", \"mod_hash\", \"train_hash\", \"data_hash\", \"group_id\", \"seed\", \"train_type\", \"schedule\", \"max_epoch\"when creating datasets\n",
+      "25-09-2019:16:34:57 INFO     configs.py           203:\t Loading None dataset with tier=train\n",
+      "25-09-2019:16:34:57 INFO     data_schemas.py     1052:\t Fetching data for {'net_hash': '80d0d4bc112470b2ba04cd5eba048e39', 'core_hash': '28bc2fa358337c5012278f899b5b6947', 'ro_hash': 'e4cd67efe5a543b044cf8a74e440775e', 'shift_hash': '05c69a4aeaeea5e48fa8fc5e70181d67', 'mod_hash': 'a757e992ae449e3057ff1d512a51bd1e', 'train_hash': '2c25349fa0a81afbe907882e7b50a4da', 'data_hash': '7572eed73113c993e7d1b92f83e270b4', 'group_id': 29, 'seed': 1215, 'data_description': \"V1 L2/3 on stimulus.Frame. normalize=True on all (except '')\", 'stats_source': 'all', 'normalize': 1, 'normalize_per_image': 0, 'layer': 'L2/3', 'brain_area': 'V1'}\n",
+      "25-09-2019:16:34:57 INFO     data_schemas.py     1062:\t Data will be (images,behavior,pupil_center,responses)\n",
+      "25-09-2019:16:34:57 INFO     data_schemas.py     1065:\t Loading dataset group029-21067-9-17-0 --> /external/cache/static21067-9-17-preproc0.h5\n",
+      "25-09-2019:16:34:57 INFO     configs.py           208:\t Adding stats_source \"all\" to dataset\n",
+      "25-09-2019:16:34:57 INFO     configs.py           211:\t Using statistics source all\n",
+      "25-09-2019:16:34:57 INFO     configs.py            85:\t Excluding \"\" from normalization\n",
+      "25-09-2019:16:34:57 INFO     configs.py           177:\t Using stimulus.Frame as stimulus type for all datasets\n",
+      "25-09-2019:16:34:57 INFO     configs.py           180:\t Stimulus sources: \"stimulus.Frame\"\n",
+      "25-09-2019:16:34:57 INFO     configs.py           114:\t Using all trial from stimulus.Frame\n",
+      "25-09-2019:16:34:57 INFO     configs.py           188:\t Selecting trials from stimulus.Frame and tier=train for dataset group029-21067-9-17-0\n",
+      "25-09-2019:16:34:57 INFO     configs.py           190:\t Found 4475 active trials\n",
+      "25-09-2019:16:34:57 INFO     configs.py           150:\t Loader sampler is SubsetRandomSampler\n",
+      "25-09-2019:16:34:57 INFO     configs.py           152:\t Number of samples in the loader will be 4475\n",
+      "25-09-2019:16:34:57 INFO     configs.py           154:\t Number of batches in the loader will be 75\n",
+      "25-09-2019:16:34:57 INFO     configs.py           233:\t Subsampling to layer L2/3 and area(s) \"V1\"\n",
+      "25-09-2019:16:34:57 INFO     configs.py           399:\t Setting cuda=False\n",
+      "25-09-2019:16:34:57 INFO     cores.py              77:\t Ignoring input {'core_hash': '28bc2fa358337c5012278f899b5b6947'} when creating GaussianLaplaceCore\n",
+      "25-09-2019:16:34:57 INFO     readouts.py          140:\t Ignoring input {'ro_hash': 'e4cd67efe5a543b044cf8a74e440775e'} when creating SpatialTransformerPyramid2dReadout\n",
+      "25-09-2019:16:34:57 INFO     shifters.py           55:\t Ignoring input {'shift_hash': '05c69a4aeaeea5e48fa8fc5e70181d67'} when creating MLPShifter\n",
+      "25-09-2019:16:34:57 INFO     shifters.py           27:\t Ignoring input {} when creating MLP\n",
+      "25-09-2019:16:34:57 INFO     modulators.py         47:\t Ignoring input {'mod_hash': 'a757e992ae449e3057ff1d512a51bd1e'} when creating MLPModulator\n",
+      "25-09-2019:16:34:57 INFO     modulators.py         18:\t Ignoring input {} when creating MLP\n"
      ]
     },
     {
@@ -150,33 +150,33 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "04-09-2019:20:15:48 WARNING  models.py             82:\t Could not find paramater 'core.features.layer0.norm.num_batches_tracked' setting to initialization value\n",
-      "04-09-2019:20:15:48 WARNING  models.py             82:\t Could not find paramater 'core.features.layer1.norm.num_batches_tracked' setting to initialization value\n",
-      "04-09-2019:20:15:48 WARNING  models.py             82:\t Could not find paramater 'core.features.layer2.norm.num_batches_tracked' setting to initialization value\n",
-      "04-09-2019:20:15:48 INFO     configs.py           224:\t Ignoring input arguments: \"net_hash\", \"core_hash\", \"ro_hash\", \"shift_hash\", \"mod_hash\", \"train_hash\", \"data_hash\", \"group_id\", \"seed\", \"train_type\", \"schedule\", \"max_epoch\"when creating datasets\n",
-      "04-09-2019:20:15:48 INFO     configs.py           203:\t Loading None dataset with tier=train\n",
-      "04-09-2019:20:15:48 INFO     data_schemas.py      977:\t Fetching data for {'net_hash': '80d0d4bc112470b2ba04cd5eba048e39', 'core_hash': '28bc2fa358337c5012278f899b5b6947', 'ro_hash': 'e4cd67efe5a543b044cf8a74e440775e', 'shift_hash': '05c69a4aeaeea5e48fa8fc5e70181d67', 'mod_hash': 'a757e992ae449e3057ff1d512a51bd1e', 'train_hash': '2c25349fa0a81afbe907882e7b50a4da', 'data_hash': '7572eed73113c993e7d1b92f83e270b4', 'group_id': 29, 'seed': 2606, 'data_description': \"V1 L2/3 on stimulus.Frame. normalize=True on all (except '')\", 'stats_source': 'all', 'normalize': 1, 'normalize_per_image': 0, 'layer': 'L2/3', 'brain_area': 'V1'}\n",
-      "04-09-2019:20:15:48 INFO     data_schemas.py      987:\t Data will be (images,behavior,pupil_center,responses)\n",
-      "04-09-2019:20:15:48 INFO     data_schemas.py      990:\t Loading dataset group029-21067-9-17-0 --> /external/cache/static21067-9-17-preproc0.h5\n",
-      "04-09-2019:20:15:48 INFO     configs.py           208:\t Adding stats_source \"all\" to dataset\n",
-      "04-09-2019:20:15:48 INFO     configs.py           211:\t Using statistics source all\n",
-      "04-09-2019:20:15:48 INFO     configs.py            85:\t Excluding \"\" from normalization\n",
-      "04-09-2019:20:15:48 INFO     configs.py           177:\t Using stimulus.Frame as stimulus type for all datasets\n",
-      "04-09-2019:20:15:48 INFO     configs.py           180:\t Stimulus sources: \"stimulus.Frame\"\n",
-      "04-09-2019:20:15:48 INFO     configs.py           114:\t Using all trial from stimulus.Frame\n",
-      "04-09-2019:20:15:48 INFO     configs.py           188:\t Selecting trials from stimulus.Frame and tier=train for dataset group029-21067-9-17-0\n",
-      "04-09-2019:20:15:48 INFO     configs.py           190:\t Found 4475 active trials\n",
-      "04-09-2019:20:15:48 INFO     configs.py           150:\t Loader sampler is SubsetRandomSampler\n",
-      "04-09-2019:20:15:48 INFO     configs.py           152:\t Number of samples in the loader will be 4475\n",
-      "04-09-2019:20:15:48 INFO     configs.py           154:\t Number of batches in the loader will be 75\n",
-      "04-09-2019:20:15:48 INFO     configs.py           233:\t Subsampling to layer L2/3 and area(s) \"V1\"\n",
-      "04-09-2019:20:15:48 INFO     configs.py           399:\t Setting cuda=False\n",
-      "04-09-2019:20:15:48 INFO     cores.py              77:\t Ignoring input {'core_hash': '28bc2fa358337c5012278f899b5b6947'} when creating GaussianLaplaceCore\n",
-      "04-09-2019:20:15:48 INFO     readouts.py          140:\t Ignoring input {'ro_hash': 'e4cd67efe5a543b044cf8a74e440775e'} when creating SpatialTransformerPyramid2dReadout\n",
-      "04-09-2019:20:15:48 INFO     shifters.py           55:\t Ignoring input {'shift_hash': '05c69a4aeaeea5e48fa8fc5e70181d67'} when creating MLPShifter\n",
-      "04-09-2019:20:15:48 INFO     shifters.py           27:\t Ignoring input {} when creating MLP\n",
-      "04-09-2019:20:15:48 INFO     modulators.py         47:\t Ignoring input {'mod_hash': 'a757e992ae449e3057ff1d512a51bd1e'} when creating MLPModulator\n",
-      "04-09-2019:20:15:48 INFO     modulators.py         18:\t Ignoring input {} when creating MLP\n"
+      "25-09-2019:16:34:57 WARNING  models.py             82:\t Could not find paramater 'core.features.layer2.norm.num_batches_tracked' setting to initialization value\n",
+      "25-09-2019:16:34:57 WARNING  models.py             82:\t Could not find paramater 'core.features.layer0.norm.num_batches_tracked' setting to initialization value\n",
+      "25-09-2019:16:34:57 WARNING  models.py             82:\t Could not find paramater 'core.features.layer1.norm.num_batches_tracked' setting to initialization value\n",
+      "25-09-2019:16:34:57 INFO     configs.py           224:\t Ignoring input arguments: \"net_hash\", \"core_hash\", \"ro_hash\", \"shift_hash\", \"mod_hash\", \"train_hash\", \"data_hash\", \"group_id\", \"seed\", \"train_type\", \"schedule\", \"max_epoch\"when creating datasets\n",
+      "25-09-2019:16:34:57 INFO     configs.py           203:\t Loading None dataset with tier=train\n",
+      "25-09-2019:16:34:57 INFO     data_schemas.py     1052:\t Fetching data for {'net_hash': '80d0d4bc112470b2ba04cd5eba048e39', 'core_hash': '28bc2fa358337c5012278f899b5b6947', 'ro_hash': 'e4cd67efe5a543b044cf8a74e440775e', 'shift_hash': '05c69a4aeaeea5e48fa8fc5e70181d67', 'mod_hash': 'a757e992ae449e3057ff1d512a51bd1e', 'train_hash': '2c25349fa0a81afbe907882e7b50a4da', 'data_hash': '7572eed73113c993e7d1b92f83e270b4', 'group_id': 29, 'seed': 2606, 'data_description': \"V1 L2/3 on stimulus.Frame. normalize=True on all (except '')\", 'stats_source': 'all', 'normalize': 1, 'normalize_per_image': 0, 'layer': 'L2/3', 'brain_area': 'V1'}\n",
+      "25-09-2019:16:34:57 INFO     data_schemas.py     1062:\t Data will be (images,behavior,pupil_center,responses)\n",
+      "25-09-2019:16:34:57 INFO     data_schemas.py     1065:\t Loading dataset group029-21067-9-17-0 --> /external/cache/static21067-9-17-preproc0.h5\n",
+      "25-09-2019:16:34:57 INFO     configs.py           208:\t Adding stats_source \"all\" to dataset\n",
+      "25-09-2019:16:34:57 INFO     configs.py           211:\t Using statistics source all\n",
+      "25-09-2019:16:34:57 INFO     configs.py            85:\t Excluding \"\" from normalization\n",
+      "25-09-2019:16:34:57 INFO     configs.py           177:\t Using stimulus.Frame as stimulus type for all datasets\n",
+      "25-09-2019:16:34:57 INFO     configs.py           180:\t Stimulus sources: \"stimulus.Frame\"\n",
+      "25-09-2019:16:34:57 INFO     configs.py           114:\t Using all trial from stimulus.Frame\n",
+      "25-09-2019:16:34:57 INFO     configs.py           188:\t Selecting trials from stimulus.Frame and tier=train for dataset group029-21067-9-17-0\n",
+      "25-09-2019:16:34:57 INFO     configs.py           190:\t Found 4475 active trials\n",
+      "25-09-2019:16:34:57 INFO     configs.py           150:\t Loader sampler is SubsetRandomSampler\n",
+      "25-09-2019:16:34:57 INFO     configs.py           152:\t Number of samples in the loader will be 4475\n",
+      "25-09-2019:16:34:57 INFO     configs.py           154:\t Number of batches in the loader will be 75\n",
+      "25-09-2019:16:34:57 INFO     configs.py           233:\t Subsampling to layer L2/3 and area(s) \"V1\"\n",
+      "25-09-2019:16:34:57 INFO     configs.py           399:\t Setting cuda=False\n",
+      "25-09-2019:16:34:57 INFO     cores.py              77:\t Ignoring input {'core_hash': '28bc2fa358337c5012278f899b5b6947'} when creating GaussianLaplaceCore\n",
+      "25-09-2019:16:34:57 INFO     readouts.py          140:\t Ignoring input {'ro_hash': 'e4cd67efe5a543b044cf8a74e440775e'} when creating SpatialTransformerPyramid2dReadout\n",
+      "25-09-2019:16:34:57 INFO     shifters.py           55:\t Ignoring input {'shift_hash': '05c69a4aeaeea5e48fa8fc5e70181d67'} when creating MLPShifter\n",
+      "25-09-2019:16:34:57 INFO     shifters.py           27:\t Ignoring input {} when creating MLP\n",
+      "25-09-2019:16:34:57 INFO     modulators.py         47:\t Ignoring input {'mod_hash': 'a757e992ae449e3057ff1d512a51bd1e'} when creating MLPModulator\n",
+      "25-09-2019:16:34:57 INFO     modulators.py         18:\t Ignoring input {} when creating MLP\n"
      ]
     },
     {
@@ -191,33 +191,33 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "04-09-2019:20:15:48 WARNING  models.py             82:\t Could not find paramater 'core.features.layer0.norm.num_batches_tracked' setting to initialization value\n",
-      "04-09-2019:20:15:48 WARNING  models.py             82:\t Could not find paramater 'core.features.layer1.norm.num_batches_tracked' setting to initialization value\n",
-      "04-09-2019:20:15:48 WARNING  models.py             82:\t Could not find paramater 'core.features.layer2.norm.num_batches_tracked' setting to initialization value\n",
-      "04-09-2019:20:15:48 INFO     configs.py           224:\t Ignoring input arguments: \"net_hash\", \"core_hash\", \"ro_hash\", \"shift_hash\", \"mod_hash\", \"train_hash\", \"data_hash\", \"group_id\", \"seed\", \"train_type\", \"schedule\", \"max_epoch\"when creating datasets\n",
-      "04-09-2019:20:15:48 INFO     configs.py           203:\t Loading None dataset with tier=train\n",
-      "04-09-2019:20:15:48 INFO     data_schemas.py      977:\t Fetching data for {'net_hash': '80d0d4bc112470b2ba04cd5eba048e39', 'core_hash': '28bc2fa358337c5012278f899b5b6947', 'ro_hash': 'e4cd67efe5a543b044cf8a74e440775e', 'shift_hash': '05c69a4aeaeea5e48fa8fc5e70181d67', 'mod_hash': 'a757e992ae449e3057ff1d512a51bd1e', 'train_hash': '2c25349fa0a81afbe907882e7b50a4da', 'data_hash': '7572eed73113c993e7d1b92f83e270b4', 'group_id': 29, 'seed': 99999, 'data_description': \"V1 L2/3 on stimulus.Frame. normalize=True on all (except '')\", 'stats_source': 'all', 'normalize': 1, 'normalize_per_image': 0, 'layer': 'L2/3', 'brain_area': 'V1'}\n",
-      "04-09-2019:20:15:48 INFO     data_schemas.py      987:\t Data will be (images,behavior,pupil_center,responses)\n",
-      "04-09-2019:20:15:48 INFO     data_schemas.py      990:\t Loading dataset group029-21067-9-17-0 --> /external/cache/static21067-9-17-preproc0.h5\n",
-      "04-09-2019:20:15:48 INFO     configs.py           208:\t Adding stats_source \"all\" to dataset\n",
-      "04-09-2019:20:15:48 INFO     configs.py           211:\t Using statistics source all\n",
-      "04-09-2019:20:15:48 INFO     configs.py            85:\t Excluding \"\" from normalization\n",
-      "04-09-2019:20:15:48 INFO     configs.py           177:\t Using stimulus.Frame as stimulus type for all datasets\n",
-      "04-09-2019:20:15:48 INFO     configs.py           180:\t Stimulus sources: \"stimulus.Frame\"\n",
-      "04-09-2019:20:15:48 INFO     configs.py           114:\t Using all trial from stimulus.Frame\n",
-      "04-09-2019:20:15:48 INFO     configs.py           188:\t Selecting trials from stimulus.Frame and tier=train for dataset group029-21067-9-17-0\n",
-      "04-09-2019:20:15:48 INFO     configs.py           190:\t Found 4475 active trials\n",
-      "04-09-2019:20:15:48 INFO     configs.py           150:\t Loader sampler is SubsetRandomSampler\n",
-      "04-09-2019:20:15:48 INFO     configs.py           152:\t Number of samples in the loader will be 4475\n",
-      "04-09-2019:20:15:48 INFO     configs.py           154:\t Number of batches in the loader will be 75\n",
-      "04-09-2019:20:15:48 INFO     configs.py           233:\t Subsampling to layer L2/3 and area(s) \"V1\"\n",
-      "04-09-2019:20:15:48 INFO     configs.py           399:\t Setting cuda=False\n",
-      "04-09-2019:20:15:48 INFO     cores.py              77:\t Ignoring input {'core_hash': '28bc2fa358337c5012278f899b5b6947'} when creating GaussianLaplaceCore\n",
-      "04-09-2019:20:15:48 INFO     readouts.py          140:\t Ignoring input {'ro_hash': 'e4cd67efe5a543b044cf8a74e440775e'} when creating SpatialTransformerPyramid2dReadout\n",
-      "04-09-2019:20:15:48 INFO     shifters.py           55:\t Ignoring input {'shift_hash': '05c69a4aeaeea5e48fa8fc5e70181d67'} when creating MLPShifter\n",
-      "04-09-2019:20:15:48 INFO     shifters.py           27:\t Ignoring input {} when creating MLP\n",
-      "04-09-2019:20:15:48 INFO     modulators.py         47:\t Ignoring input {'mod_hash': 'a757e992ae449e3057ff1d512a51bd1e'} when creating MLPModulator\n",
-      "04-09-2019:20:15:48 INFO     modulators.py         18:\t Ignoring input {} when creating MLP\n"
+      "25-09-2019:16:34:58 WARNING  models.py             82:\t Could not find paramater 'core.features.layer2.norm.num_batches_tracked' setting to initialization value\n",
+      "25-09-2019:16:34:58 WARNING  models.py             82:\t Could not find paramater 'core.features.layer0.norm.num_batches_tracked' setting to initialization value\n",
+      "25-09-2019:16:34:58 WARNING  models.py             82:\t Could not find paramater 'core.features.layer1.norm.num_batches_tracked' setting to initialization value\n",
+      "25-09-2019:16:34:58 INFO     configs.py           224:\t Ignoring input arguments: \"net_hash\", \"core_hash\", \"ro_hash\", \"shift_hash\", \"mod_hash\", \"train_hash\", \"data_hash\", \"group_id\", \"seed\", \"train_type\", \"schedule\", \"max_epoch\"when creating datasets\n",
+      "25-09-2019:16:34:58 INFO     configs.py           203:\t Loading None dataset with tier=train\n",
+      "25-09-2019:16:34:58 INFO     data_schemas.py     1052:\t Fetching data for {'net_hash': '80d0d4bc112470b2ba04cd5eba048e39', 'core_hash': '28bc2fa358337c5012278f899b5b6947', 'ro_hash': 'e4cd67efe5a543b044cf8a74e440775e', 'shift_hash': '05c69a4aeaeea5e48fa8fc5e70181d67', 'mod_hash': 'a757e992ae449e3057ff1d512a51bd1e', 'train_hash': '2c25349fa0a81afbe907882e7b50a4da', 'data_hash': '7572eed73113c993e7d1b92f83e270b4', 'group_id': 29, 'seed': 99999, 'data_description': \"V1 L2/3 on stimulus.Frame. normalize=True on all (except '')\", 'stats_source': 'all', 'normalize': 1, 'normalize_per_image': 0, 'layer': 'L2/3', 'brain_area': 'V1'}\n",
+      "25-09-2019:16:34:58 INFO     data_schemas.py     1062:\t Data will be (images,behavior,pupil_center,responses)\n",
+      "25-09-2019:16:34:58 INFO     data_schemas.py     1065:\t Loading dataset group029-21067-9-17-0 --> /external/cache/static21067-9-17-preproc0.h5\n",
+      "25-09-2019:16:34:58 INFO     configs.py           208:\t Adding stats_source \"all\" to dataset\n",
+      "25-09-2019:16:34:58 INFO     configs.py           211:\t Using statistics source all\n",
+      "25-09-2019:16:34:58 INFO     configs.py            85:\t Excluding \"\" from normalization\n",
+      "25-09-2019:16:34:58 INFO     configs.py           177:\t Using stimulus.Frame as stimulus type for all datasets\n",
+      "25-09-2019:16:34:58 INFO     configs.py           180:\t Stimulus sources: \"stimulus.Frame\"\n",
+      "25-09-2019:16:34:58 INFO     configs.py           114:\t Using all trial from stimulus.Frame\n",
+      "25-09-2019:16:34:58 INFO     configs.py           188:\t Selecting trials from stimulus.Frame and tier=train for dataset group029-21067-9-17-0\n",
+      "25-09-2019:16:34:58 INFO     configs.py           190:\t Found 4475 active trials\n",
+      "25-09-2019:16:34:58 INFO     configs.py           150:\t Loader sampler is SubsetRandomSampler\n",
+      "25-09-2019:16:34:58 INFO     configs.py           152:\t Number of samples in the loader will be 4475\n",
+      "25-09-2019:16:34:58 INFO     configs.py           154:\t Number of batches in the loader will be 75\n",
+      "25-09-2019:16:34:58 INFO     configs.py           233:\t Subsampling to layer L2/3 and area(s) \"V1\"\n",
+      "25-09-2019:16:34:58 INFO     configs.py           399:\t Setting cuda=False\n",
+      "25-09-2019:16:34:58 INFO     cores.py              77:\t Ignoring input {'core_hash': '28bc2fa358337c5012278f899b5b6947'} when creating GaussianLaplaceCore\n",
+      "25-09-2019:16:34:58 INFO     readouts.py          140:\t Ignoring input {'ro_hash': 'e4cd67efe5a543b044cf8a74e440775e'} when creating SpatialTransformerPyramid2dReadout\n",
+      "25-09-2019:16:34:58 INFO     shifters.py           55:\t Ignoring input {'shift_hash': '05c69a4aeaeea5e48fa8fc5e70181d67'} when creating MLPShifter\n",
+      "25-09-2019:16:34:58 INFO     shifters.py           27:\t Ignoring input {} when creating MLP\n",
+      "25-09-2019:16:34:58 INFO     modulators.py         47:\t Ignoring input {'mod_hash': 'a757e992ae449e3057ff1d512a51bd1e'} when creating MLPModulator\n",
+      "25-09-2019:16:34:58 INFO     modulators.py         18:\t Ignoring input {} when creating MLP\n"
      ]
     },
     {
@@ -232,9 +232,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "04-09-2019:20:15:49 WARNING  models.py             82:\t Could not find paramater 'core.features.layer0.norm.num_batches_tracked' setting to initialization value\n",
-      "04-09-2019:20:15:49 WARNING  models.py             82:\t Could not find paramater 'core.features.layer1.norm.num_batches_tracked' setting to initialization value\n",
-      "04-09-2019:20:15:49 WARNING  models.py             82:\t Could not find paramater 'core.features.layer2.norm.num_batches_tracked' setting to initialization value\n"
+      "25-09-2019:16:34:58 WARNING  models.py             82:\t Could not find paramater 'core.features.layer2.norm.num_batches_tracked' setting to initialization value\n",
+      "25-09-2019:16:34:58 WARNING  models.py             82:\t Could not find paramater 'core.features.layer0.norm.num_batches_tracked' setting to initialization value\n",
+      "25-09-2019:16:34:58 WARNING  models.py             82:\t Could not find paramater 'core.features.layer1.norm.num_batches_tracked' setting to initialization value\n"
      ]
     }
    ],
@@ -252,6 +252,65 @@
     "model_key = {'group_id': key['group_id'], 'net_hash': key['net_hash']}\n",
     "my_models = [(static_models.Model & mk).load_network() for mk in (static_models.Model & model_key).proj()]\n",
     "model = models.Ensemble(my_models, key['readout_key'], eye_pos=mean_eyepos, neuron_idx=key['neuron_id'], device=device)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dset = train_stats[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "60.928997"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dset.images[dset.tiers == 'train'].std()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(Tensor images: (5998, 1, 36, 64) \n",
+       " Tensor behavior: (5998, 3) \n",
+       " Tensor pupil_center: (5998, 2) \n",
+       " Tensor responses: (5998, 8097) \n",
+       " Transforms: [Normalizer, Subsample(n=8097), ToTensor]\n",
+       " \t[Stats source: all],\n",
+       " (1, 1, 36, 64),\n",
+       " 111.29832458496094,\n",
+       " tensor([[2.0885, 0.1164, 0.0178]], device='cuda:0'),\n",
+       " tensor([[0., 0.]], device='cuda:0'),\n",
+       " 60.92904281616211)"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "train_stats"
    ]
   },
   {
@@ -891,92 +950,6 @@
     "for ax, i, one_x in zip(axes[1:], range(20, 101, 20), opt_x):\n",
     "    ax.imshow(one_x.squeeze().detach().cpu().numpy())\n",
     "    ax.set_title('Iter {}: f(x) = {:.2f}'.format(i, fevals[i]))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Create an MEI in the center of the screen\n",
-    "Just to show `x_shift` and `y_shift`:\n",
-    "* Sending `eye_pos=None` (default) gets rid of the overall pupil shift.\n",
-    "* Sending `x_shift=0` and `y_shift=0` gets rid of the per-cell learnt shift.\n",
-    "\n",
-    "Note: This centers the readout of each model to happen exactly in the center of the image. If you are using an ensemble of models, this assumes that each model learnt the readout in the same position in the image which does not need to be true---this is, in fact, false for most of our models."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "center_model = models.Ensemble(my_models, key['readout_key'], neuron_idx=key['neuron_id'], \n",
-    "                               x_shift=0, y_shift=0, device=device)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "initial_image_square = torch.randn(1, 1, 32+14, 32+14, dtype=torch.float32, device=device)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Iter 100: f(x) = 393.37, reg(x) = 0.00, std(x) = 43.19\n",
-      "Final f(x) = 397.32\n"
-     ]
-    }
-   ],
-   "source": [
-    "opt_x, fevals, reg_values = featurevis.gradient_ascent(center_model, initial_image_square, step_size=100, num_iterations=100)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[<matplotlib.axis.XTick at 0x7fc7d1cf1e80>]"
-      ]
-     },
-     "execution_count": 29,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA7gAAAEvCAYAAABvxW2JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nOzdeZhcZZn38e/TWzp7yEpWEpKQjS3QBARUVlkl6jiIuKAyMjqozIyj4kYCAqKgiLJoBAVURIfRSQhhDSCLrAEEOjvZQ/Z96/T2vH90OW8kdUJXUpXTXf39XFeu7nrq1HPuOnW6u+6cU78TYoxIkiRJktTalaRdgCRJkiRJ+WCDK0mSJEkqCja4kiRJkqSiYIMrSZIkSSoKNriSJEmSpKJggytJkiRJKgplaRcA0LNnzzh48OC0y5AkqcWZMWPG2hhjr7TrkPKttGPHWN6te/MfEBLG83HFy0LOrb3Ss105a2vrdr/D10TAzreXJf5tbBEN7uDBg3n55ZfTLkOSpBYnhLA47RqkQijv1p2Bl/5H8x9gg9umXHZwf25auHz3O3xNBMz/9lcT/zZ6irIkSZIkqSjY4EqSJEmSioINriRJkiSpKNjgSpIkSZKKQosImZIkSZL2qJDhQgYXtUy+LoWVj3C1FhjQ1uwjuCGE0hDCqyGEqZnbQ0IIL4QQ5ocQ/hBCqMiMt8vcnp+5f3BhSpckSZIk6f/L5RTly4BZu9z+AXBjjHEYsAG4ODN+MbAhM35jZjlJkiRJkgqqWQ1uCGEAcA5we+Z2AE4B7ssschfwocz34zO3ydx/amZ5SZIkSZIKprlHcH8CfB1ozNzuAWyMMdZnbi8D+me+7w8sBcjcvymzvCRJkiRJBfOuDW4I4VxgdYxxRj5XHEK4JITwcgjh5TVr1uRzakmS9ruXF63nidmr0y5DkqQ2rTkpyicA54UQzgYqgS7ATUC3EEJZ5ijtAGB5ZvnlwEBgWQihDOgKrHvnpDHGScAkgKqqKjPSJEmt0urNNVz34Gz+9OpyjhzYjZNG9MJP5khqllwTaAu9fBr29Osy23251p6Pbdaat++e5KPOQj/Xvfhz+q5HcGOM34wxDogxDgYuAB6PMX4CeAL4aGaxi4DJme+nZG6Tuf/xGGNreZklSWqWuoZGfvnUAk750V+Y+voKvnTyMO75/LE2t5IkpWhfroP7DeDeEMLVwKvAHZnxO4DfhBDmA+tpaoolSSoaz8xby8T7q5m/eiunjOzNFeeOZnDPjmmXJUlSm5dTgxtjfBJ4MvP9AmBclmVqgH/OQ22SJLUoyzfu4JoHZjLtjZUM6t6B2z9dxWmj+6RdliRJytiXI7iSJLUJNXUN3P70Am5+Yj4AXz39ED7/voOpLC9NuTJJkrQrG1xJkvbg8dmruPL+mSxet50zxxzId84dxYADOqRdliRJysIGV5KkLBav28ZV989k+uzVDO3Vkd9efCwnDu+ZdlmSikmuMayFXj6bQicF52ueXPP9clm+0NugtacxF9JebAMbXEmSdrG9tp5bn3iLSU8toLw08O2zR3HR8YOpKHvXCw9IkqSU2eBKkgTEGHnwzZVcPXUmb2+q4UNH9uNbZ4+id5fKtEuTJEnNZIMrSWrz5q/ewsQpM3lm/lpGHtiZn1wwlnFDuqddliRJypENriSpzdpSU8dPp8/j188uokNFKVeNH8OF4wZRVurpyJIktUY2uJKkNifGyP++tpxrp81m7dadfKxqIF87YwQ9OrVLuzRJkrQPbHAlSW1K9dubmDilmpcWbeCIAV355aerOHJgt7TLktqeQPb02KTU1DSSZk23zV2uaca5bstc528N0tqfinT/tsGVJLUJG7fX8uNH5/Lb5xfTrUMF133kMM6vGkhJSTG+W5IkqW2ywZUkFbXGxsgfX17KDx+ew8bttXzquIP4z9NH0LVDedqlSZKkPLPBlSQVrdeWbmTC5Df527JNjBvcnYnnjWF0vy5plyVJkgrEBleSVHTWbt3JDx+azR9fXkbvzu246YIjOe+IfoTg6ciSJBUzG1xJUtGob2jkt88v5kePzmVHbQOXvO9gvnLqcDq188+dJEltgX/xJUlF4YUF65gwpZrZK7dw4rCeTDxvNMN6d067LElJIrmltaaRrpyvhN/WkkqbxkkuBV5nTJg/FGP6dhoJ1i1w37bBlSS1aqs213DttFlMfu1t+ndrz88/eRRnjDnQ05ElSWqDbHAlSa1SbX0jv352IT+dPo+6xsiXTxnGv500jPYVpWmXJkmSUmKDK0lqdZ6et4YJU6pZsGYbp43qzXfPHc1BPTqmXZYkSUqZDa4kqdVYtmE7V0+dxUPVKzmoRwd+9ZkqThnZJ+2yJElSC2GDK0lq8WrqGvjFXxZw65PzKQmBr50xgotPHEJluacjSyqglvZR/pYUYpWnbZMUApWveQoaJpWrQr9+hX6uLWlb7oENriSpxYox8tis1Vw1tZql63dwzuF9+fbZo+jXrX3apUmSpBbIBleS1CItXLuNK++v5sk5axjeuxP3/MuxHD+sZ9plSZKkFuxdG9wQQiXwFNAus/x9McYJIYQ7gfcDmzKLfibG+Fpoui7DTcDZwPbM+CuFKF6SVHy219ZzyxPz+eVTC6koK+E754ziouMHU15aknZpkiSphWvOEdydwCkxxq0hhHLgmRDCg5n7vhZjvO8dy58FDM/8Oxa4LfNVkqREMUYeeGMF1zwwixWbavjIUf25/KyR9O5cmXZpkiSplXjXBjfGGIGtmZvlmX97+ojxeODuzOOeDyF0CyH0jTGu2OdqJUlFae6qLUyYXM1zC9Yxum8XfvbxsVQN7p52WZIkqZVp1mdwQwilwAxgGHBLjPGFEMIXgWtCCFcA04HLY4w7gf7A0l0eviwzZoMrSfoHm2vquOmxedz510V0alfG9z50KBeOG0RpSUuLLpWUd4HsqbK5JrUmLZ9LYm1LSifek3zVk4dfsbmmFucr5Thvacm5LJ+vP0lJ68x1H05LPn5e94NmNbgxxgbgyBBCN+DPIYRDgW8CK4EKYBLwDeCq5q44hHAJcAnAoEGDcixbktSaNTZG/vzqcr7/4GzWbdvJBccM4mtnjKB7x4q0S5MkSa1YTinKMcaNIYQngDNjjDdkhneGEH4N/Ffm9nJg4C4PG5AZe+dck2hqjKmqqmqBvb8kqRDeXL6JCVOqmbF4A0cO7MavP3MMhw3omnZZkiSpCDQnRbkXUJdpbtsDpwM/+PvnajOpyR8C3sw8ZArwpRDCvTSFS23y87eSpA3barnhkTnc8+ISuneo4PqPHs4/HTWAEk9HliRJedKcI7h9gbsyn8MtAf4YY5waQng80/wG4DXgC5nlp9F0iaD5NF0m6LP5L1uS1Fo0NEbufWkJ1z88hy019Vz0nsH8x+mH0LV9edqlSZKkItOcFOXXgbFZxk9JWD4Cl+57aZKk1m7G4g1MmPImby7fzLFDunPl+DGMPLBL2mVJkqQildNncCVJao41W3byg4dmc9+MZfTp0o6bLjiS847oR9OnWiSJpvTVfCTZ5ppM2xoUOtW5MYf1Jqwz19/mJTmmKwNZ60yaJ1+y1pNrynHS9k2S6+ud1p/SVvIzZYMrScqb+oZG7n5uMTc+Opea+ga+8P6hfPmUYXRs558bSZJUeL7jkCTlxXNvrWPilGrmrNrCe4f3ZOJ5Yxjaq1PaZUmSpDbEBleStE9WbNrBNQ/MYurrKxhwQHt+8amj+cDoPp6OLEmS9jsbXEnSXtlZ38Adzyzk5sfn09AY+ffThvOF9w+lsrw07dIkSVIbZYMrScrZk3NWc+X9M1m4dhunj+7DFeeOZmD3DmmXJUmS2jgbXElSsy1dv52rps7k0ZmrGNKzI3d+9hhOGtE77bIktQWFTHBtaemwudaTa9puLp8gyfXTJjmmJYd8bfs9xjEXaMW5TtFa0pJbORtcSdK7qqlr4LYn3+Lnf3mL0pLAN84cyedOHEy7Mk9HliRJLYcNriQpUYyRh6tXcfUDM1m2YQcfPKIf3zp7JH27tk+7NEmSpN3Y4EqSsnprzVauvH8mT81dw4g+nfn954/jPUN7pF2WJElSIhtcSdI/2Lqznp89Po9fPbOQyrJSrjh3NJ9+z0GUlZakXZokSdIe2eBKkoCm05Gn/O1trp02i1Wbd/LPRw/g62eOpFfndmmXJkmS1Cw2uJIkZq3YzIQp1by4cD2H9u/CbZ88mqMGHZB2WZKUf9mSaVtainK+0nZzTOHNFkQcGnObI1eJ4ccxx6DjHFORcw1dzotCp2MLsMGVpDZt0446bnx0Lr95fjGdK8u49sOH8bFjBlJa4l9PSZLU+tjgSlIb1NgYuW/GMn7w0Gw2bK/lwmMH8dXTR3BAx4q0S5MkSdprNriS1Ma8vmwj351czd+WbuTogw7grvPGcWj/rmmXJUmStM9scCWpjVi/rZbrH57NvS8tpUfHdvz4/CP48Nj+hODpyJIkqTjY4EpSkWtojNzzwmJueGQu23bW87kThvDvpw2nc2V52qVJkiTllQ2uJBWxlxet54rJ1cxcsZnjh/bgyvPGMLxP57TLkqSmJNhcEo3zlSycUzJvHubI5/wFTtUNDVnG8vVck2KL87SCxFTk1nCSUktL8W7lbHAlqQit3lzDdQ/O5k+vLqdf10pu/cRRnHXogZ6OLEmSipoNriQVkbqGRu58dhE3TZ9HbX0jl548lEtPHkaHCn/dS5Kk4uc7HkkqEs/OX8uEKdXMX72Vk0f0YsIHxzC4Z8e0y5IkSdpv3rXBDSFUAk8B7TLL3xdjnBBCGALcC/QAZgCfijHWhhDaAXcDRwPrgI/FGBcVqH5JavOWb9zBNQ/MZNobKxnUvQN3XFTFqaP6pF2WJEnSftecI7g7gVNijFtDCOXAMyGEB4H/BG6MMd4bQvg5cDFwW+brhhjjsBDCBcAPgI8VqH5JarNq6hq4/ekF3PzEfAC+evohfP59B1NZXppyZZIkSel41wY3xhiBrZmb5Zl/ETgFuDAzfhcwkaYGd3zme4D7gJtDCCEzjyQpD6bPWsWV989kyfrtnH3YgXz7nNH079Y+7bIkqfkiuaXHFjhBOBW5piXna/4ctlliOnHS1I05PiBhBYGQda5YkkJLkVYXk699u5A/O/maO4+J5c36DG4IoZSm05CHAbcAbwEbY4z1mUWWAf0z3/cHlgLEGOtDCJtoOo15be7lSZJ2tWjtNq6aOpPHZ69maK+O/PbiYzlxeM+0y5IkSWoRmtXgxhgbgCNDCN2APwMj93XFIYRLgEsABg0atK/TSVJR215bz61PvMWkpxZQXhr49tmjuOj4wVSUlaRdmiRJUouRU4pyjHFjCOEJ4D1AtxBCWeYo7gBgeWax5cBAYFkIoQzoSlPY1DvnmgRMAqiqqvL0ZUnKIsbIg2+u5OqpM3l7Uw0fOrIf3zp7FL27VKZdmiRJUovTnBTlXkBdprltD5xOU3DUE8BHaUpSvgiYnHnIlMzt5zL3P+7nbyUpd/NWbWHi/dU8O38do/p24ScXjGXckO5plyVJktRiNecIbl/grszncEuAP8YYp4YQZgL3hhCuBl4F7sgsfwfwmxDCfGA9cEEB6pakorWlpo6bHpvHnX9dRIeKUr43fgwfHzeIslJPR5YkSdqT5qQovw6MzTK+ABiXZbwG+Oe8VCdJbUiMkT+/upzvPzibtVt3csExA/mvD4ygR6d2aZcmSS1XrucJ5pLu2tLOQUyqPdfE2saEabI936SU44Q5ct1mWde5h7kSU5qT0pVzfQ2zPN891ti8KfYsYQV52/0KmWjcApOec/oMriSpMN5cvomJU6p5efEGjhzYjTsuquLwAd3SLkuSJKlVscGVpBRt3F7LDY/M4Z4XlnBAhwp++E+H89GjB1BS0pov7ChJkpQOG1xJSkFDY+QPLy3l+odns7mmnk+/ZzD/cfohdG1fnnZpkiRJrZYNriTtZ68s2cCEydW8sXwTxw7pzpXjxzDywC5plyVJktTq2eBK0n6yZstOfvDQbO6bsYw+Xdrx04+P5YOH9yUET0eWJEnKBxtcSSqw+oZG7n5uMTc+Opea+ga+8P6hfPmUYXRs569gSdrv0khGziWVdk/L5zpPwnhSEnFoyDKWNEeWZWEPCcIJV7qLSeNEYunuK09aPlGOr3dJUjp0PuQax5yWllTmXtTiuytJKqDn3lrHxCnVzFm1hfcO78nE88YwtFentMuSJEkqSja4klQAKzbt4JoHZjH19RX079aeX3zqaD4wuo+nI0uSJBWQDa4k5dHO+gbueGYhP5s+n4YYuezU4XzxpKFUlpemXZokSVLRs8GVpDx5cs5qrrx/JgvXbuMDo/vw3XNHM7B7h7TLkiRJajNscCVpHy1dv52rps7k0ZmrGNKzI3d+9hhOGtE77bIkSZLaHBtcSdpLNXUN3PbkW9z2l7coKwl8/cwRXHziENqVeTqyJO03uUYb5JLKmmtqcaElpiInjSc8gaTls6Uo55oqnPAnsDGh64glSU9qD4nMWSfKYVn2EGic5fkmLZuY6JzwnJKeT2sJV85JrgnheWSDK0k5ijHycPUqrn5gJss27OC8I/rxrbNHcWDXyrRLkyRJatNscCUpB2+t2crEKdU8PW8tI/p05t5LjuO4g3ukXZYkSZKwwZWkZtm6s56fPT6PXz2zkMryUiZ8cDSfOu4gykpzveK8JEmSCsUGV5L2IMbIlL+9zbXTZrFq807OrxrA188cSc9O7dIuTZIkSe9ggytJCWat2MyEKdW8uHA9h/Xvym2fPJqjBh2QdlmSJElKYIMrSe+waXsdNz42l7ufW0TX9uV8/yOHcX7VQEpL9kP0nyQpN7km0BYwmTfnefKU/JtzWnIeEm5jUipyQopyUhpz0vJJ9yXNU1qb29/opATkxvLdN06uKcpJ44nztLQU5Vz2jxTTkpPY4EpSRmNj5L9nLOUHD81h4/ZaPnHsQXz1A4fQrUNF2qVJkiSpGWxwJQn429KNXDGlmr8t3UjVQQdw5fhxjOnXNe2yJEmSlAMbXElt2rqtO7n+4Tn84eWl9OzUjhs/dgQfOrI/IXg6siRJUmtjgyupTapvaOSeF5dww8Nz2F7bwMUnDOGy04bTubI87dIkSZK0l961wQ0hDATuBvrQ9DHiSTHGm0IIE4HPA2syi34rxjgt85hvAhcDDcBXYowPF6B2SdorLy1azxWTq5m1YjMnDOvBxA+OYXifzmmXJUmSpH3UnCO49cBXY4yvhBA6AzNCCI9m7rsxxnjDrguHEEYDFwBjgH7AYyGEQ2KMDfksXJJytXpzDd9/cDZ/fnU5/bpWcusnjuKsQw/0dGRJaktaUmJtjn9+EktPmCfxz1tSmm+W1OLEpOCE9OOS+oR1JqQfl8Sk4oEs625MSm8uy/6kEtOSK5q/I4SE55SYXp00dVKqdcJ4vtK3E/ezXBOQsy2f61uoXGvZC+/a4MYYVwArMt9vCSHMAvrv4SHjgXtjjDuBhSGE+cA44Lk81CtJOautb+Suvy7iJ4/Npa4h8uVThvHFk4bSocJPaUiSJBWTnN7dhRAGA2OBF4ATgC+FED4NvEzTUd4NNDW/z+/ysGXsuSGWpIJ5et4aJk6p5q012zh1ZG++e+5oBvfsmHZZkiRJKoCEg/a7CyF0Av4H+PcY42bgNmAocCRNR3h/lMuKQwiXhBBeDiG8vGbNmnd/gCTlYNmG7XzxtzP41B0vUt8YueOiKu74zDE2t5IkSUWsWUdwQwjlNDW3v4sx/gkgxrhql/t/CUzN3FwODNzl4QMyY/8gxjgJmARQVVXVkj4NIakVq6lrYNJTC7j1yfkAfO2MEVx84hAqyxM+LCRJkqSi0ZwU5QDcAcyKMf54l/G+mc/nAnwYeDPz/RTgnhDCj2kKmRoOvJjXqiXpHWKMTJ+1mqumzmTJ+u2cc1hfvnXOKPp3a592aZKkli5fwTd5yixMzF1KCCOKJbkFLCUFRGWTGBqVUGTiOhO6jpAUQxugsbz5L0Bj0lX+kl6TpMCnLKsMDdknSXo9kp5TYphUniTtNzmHSSXJx/69Hw5rNucI7gnAp4A3QgivZca+BXw8hHAkTWUuAv4VIMZYHUL4IzCTpgTmS01QllRIC9du46r7q3lizhqG9+7EPf9yLMcP65l2WZIkSdrPmpOi/AzZ+/Vpe3jMNcA1+1CXJL2r7bX13Pz4fG5/eiEVZSV855xRXHT8YMpLmx0vIEmSpCLiNTIktToxRqa+voJrp81ixaYaPnJUfy4/ayS9O1emXZokSZJSZIMrqVWZu2oLEyZX89yCdYzp14WbLxzL0Qd1T7ssSZIktQA2uJJahc01dfzk0Xnc9dwiOleW8b0PHcqF4wZRWpKnRA9JkiS1eja4klq0xsbIn15dznUPzmLdtlouHDeI//rACA7oWJF2aZKkliAfCch5SnZNTLHNscakJOJ8pT03tsvhAQn/kRzqss9RWpMUAZ0wf0IpoS7QftXuG6KkLvvydZ2SxrOvoGxbQgp02e7LJ6VOJ6cl5/af78n7TZ52zDZ2LMAGV1KL9cayTVwx5U1eXbKRsYO6cednx3Fo/65plyVJkqQWygZXUouzYVst1z8yh9+/uIQeHSu44Z+P4CNj+1Pi6ciSJEnaAxtcSS1GQ2Pk9y8u4YZH5rClpp7PnTCEy04bTpfKpKu3S5IkSf+fDa6kFmHG4vVcMbma6rc3856DezDxvDGMOLBz2mVJkiSpFbHBlZSq1VtquO7B2fzpleX07VrJzReO5ZzD+hKCpyNLkiQpNza4klJR19DIXX9dxE8em0dtfSOXnjyUS08eRocKfy1JUpuWa1JwnoJmc5JjWnJSSm7if+XmOk9Smm/CeEld9okasyQIZxsDIMdPD5Vtz77Osprsy5fURTqs2H3dlRuzP6k1h2d//1DfK3vscn3X7FHVpVt3Hw/1CRs+KV25Mfs2S3o9tAd7cbzDd5KS9rtn569l4pRq5q3eykkjejHhg2MY0rNj2mVJkiSplbPBlbTfLN+4g2sfmMUDb6xgUPcO3P7pKk4d1dvTkSVJkpQXNriSCm5nfQO3P72Qmx+fTyTyn6cfwiXvO5jK8oRzeyRJkqS9YIMrqaCemL2aK++vZtG67Zx16IF8+5xRDDigQ9plSZIkqQjZ4EoqiMXrtnHV/TOZPns1Q3t15DcXj+O9w3ulXZYkSZKKmA2upLzaUdvArU/O5xd/WUB5aeDbZ4/iouMHU1GWPa1QkqR/kEYqcpI8RUQkhi43JtyRsA1C0rZJmCc0Zl9zqE2YKEtMc0z4NFFDZfaVNhyYPSq4tiz78iUbE+KYS6Chcvfh9it3ZF28a6fsYZU7+md//9GuZ/Z5dla0220s7Mi+EUp2JG3fHGOzk17XfEWU5DpPS/oZ3ItabHAl5UWMkQffXMnVU2fy9qYaPjy2P988ayS9u2T56yRJkiQVgA2upH02b9UWJt5fzbPz1zGqbxd+csFYxg3pnnZZkiRJamNscCXttS01dfx0+jx+/ewiOlSU8r3xY/j4uEGUlXo6siRJkvY/G1xJOYsx8udXl/P9B2ezdutOPlY1kK+dMYIenXb/3IokSZK0v9jgSsrJm8s3MXFKNS8v3sCRA7txx0VVHD6gW9plSZIkSTa4kppn4/ZabnhkDve8sIQDOlTww48ezkePGkBJSb4i/iRJauWSEl9zHE9MS05aPiktOTGlOWH5kt1XEBM+dRQaEv7+l2df6VFDF2cd/86AB7KOPzvjh2x4f81u492rsxd0wIw1WcdjafZLFG4c3jnreFlllo2csN1L6hPG6xK2TY6JwLEs+wOSXpPkiXJcviXZi7eZNriS9qihMfKHl5Zy/cOz2VxTz6ffM5j/OP0QurZPiPWXJEmSUvKuDW4IYSBwN9CHpv5/UozxphBCd+APwGBgEXB+jHFDCCEANwFnA9uBz8QYXylM+ZIK6ZUlG5gwuZo3lm/i2CHduXL8GEYe2CXtsiRJBbCH93zXAx8EaoG3gM/GGDdmefwiYAvQANTHGKv2V+2S9HfNOcBdD3w1xjgaOA64NIQwGrgcmB5jHA5Mz9wGOAsYnvl3CXBb3quWVFBrtuzkv/77b3zk1r+yeksNN11wJPdecpzNrSQVt6T3fI8Ch8YYDwfmAt/cwxwnxxiPtLmVlJZ3PYIbY1wBrMh8vyWEMAvoD4wHTsosdhfwJPCNzPjdMcYIPB9C6BZC6JuZR1ILVt/QyN3PLebGR+dSU9/AF94/lC+fMoyO7fw0gyQVu6T3fDHGR3ZZ7Hngo2nUJ0nNkdO71hDCYGAs8ALQZ5emdSVNp7NAU/O7dJeHLcuM/UODG0K4hKYjvAwaNCjHsiXl23NvrWPilGrmrNrCe4f3ZOJ5Yxjaq1PaZUmSUvCO93y7+hxNH1HLJgKPhBAi8IsY46SCFShJCZrd4IYQOgH/A/x7jHFz00dtm8QYY+aXWbNlfulNAqiqqmrN2V5Sq7Zi0w6unTab+//2Nv27tefnnzyaM8b0YdefcUlS2/HO93y7jH+bptOYf5fw0BNjjMtDCL2BR0MIs2OMT71j7v87wNGtR08uO7h/QZ5Dq5H0DjhPf4JDQlpyLqm6MUuyctMd2eeO5dmXr9yQ/bXevGNM1vF+peV8t+uA3cbrL6rIunzYvD3rOJXtsg43dMjeBjWW7/68ck4tzpOkly85Zrvt+PIe7mtWgxtCKKfpF93vYox/ygyv+vupxyGEvsDqzPhyYOAuDx+QGZPUguysb+COZxZy8+PzaWiMXHbqcL540lAqy0vTLk2SlJKE93yEED4DnAucmvkY2m5ijMszX1eHEP4MjAOeescy/3eAo7L/wHjTgixvEZPe1Of6nj4f8+SrlhwvB5TY2CQ1WgmXA0q6XE1oaP78DdkumwOE+uxz7zywLuv4iOFvZx1/aGT2ywTdOeO7TDvgr7uNr/vJ4KzLl02fkXW89JChWcc3HJ398kHb++y+Eeo7ZF2UmPCWKXH7JkiapzGhU4ulbajBLcRlgjKpyHcAs2KMP97lrinARcB1ma+Tdxn/UgjhXuBYYJOfv5ValifnrObK+2eycO02Th/dhxzSOscAACAASURBVCvOHc3A7gm/vSVJbULSe74QwpnA14H3xxizHiYLIXQESjKf3e0IfAC4aj+ULUn/oDlHcE8APgW8EUJ4LTP2LZoa2z+GEC4GFgPnZ+6bRtMlgubTdJmgz+a1Ykl7bcm67Vw1dSaPzVrFkJ4dufOzx3DSiN5plyVJahmS3vP9FGhH02nHAM/HGL8QQugH3B5jPJumLJY/Z+4vA+6JMT60v5+AJDUnRfkZkg8On5pl+Qhcuo91ScqjHbUN3PaXt/j5X96irCTwjTNH8rkTB9OuzNORJUlN9vCeb1rC8m/TdFCDGOMC4IjCVSdJzeO1P6QiFmPk4epVfG/qTJZv3MF5R/Tjm2ePpG/X9mmXJkmSJOWdDa5UpOav3sqV91fz9Ly1jOjTmXsvOY7jDu6RdlmSJO1ZvpKFC5nDk1BLYrhQUuJwUkJxUvhxQshU0qZprMg+f0lCQFTJzt3HyrYl1Z59naVbs58dtrU2e5rx/27LfknCCDRm2W47u2VvX8pKsq83Ll+Zdbz94AOyju/sWr7bWH37hG2QtOETTpBL2maNZdlfp6TwqVzDzxJDl/MRllboi27sxc+xDa5UZLburOdn0+dxxzMLaV9RyoQPjuZTxx1EWWlKGfeSJEnSfmKDKxWJGCOTX3uba6fNYvWWnZxfNYCvnzmSnp2y/4+pJEmSVGxscKUiMPPtzUycUs2Li9ZzWP+u/OJTRzN2UPZTbyRJkqRiZYMrtWKbttfx40fn8JvnF9O1fTnf/8hhnF81kNKSQn8gQpIkSWp5bHClVqixMfLHl5fyw4fnsHF7LZ887iD+8/RD6NahIu3SJEmSpNTY4EqtzGtLNzJh8pv8bdkmqg46gCvHj2NMv65plyVJUmGlkIqcq6SUXGJC8QnLJ6bzJqUr57h8fWX2ekKW2I7QmLDOpKTghPGV67tkHX+61yFZxw8nUllav9v4lgHZV9BlxMFZxxvnL8463m7l1qzjFb267TYWS7NvyPoOWYdpSDjeEMsT0pITOrKk1zUpFTlvaclJWskJgja4UiuxdutOrn9oDn94eSm9Orfjxo8dwYeO7E8IreS3jSRJklRgNrhSC1ff0Mhvn1/Mjx6dy47aBi5538F8+ZRhdK7c/TptkiRJUltmgyu1YC8sWMeEKdXMXrmFE4f1ZOJ5oxnWu3PaZUmSJEktkg2u1AKt3FTD9x+cxeTX3qZ/t/b8/JNHccaYAz0dWZIkSdoDG1ypBamtb+RXzy7kp9PnUd8Y+copw/jiScNoX5GQ2CBJkiTp/9jgSi3EU3PXMHFKNQvWbuO0UX244tzRDOqREM8nSZL2Tj5OhspTWm2u6cdJ8yel5ybNH8sSHtCw+wNKarNPUlqTUEtD9vG6dVkimoEn3x6WdfyQhnLmrO+923hN7+y17+ybPaW53ZrsH+1KeqnKana/p742+9KNZdm3TWKadkluL2zi/lForfyEQRtcKWVL12/n6gdm8nD1Kgb36MCvP3MMJ4/c/Re6JEmSpD2zwZVSUlPXwC/+soBbn5xPSQh8/cwRXHziENqVeTqyJEmStDdscKX9LMbIozNXcdXUmSzbsIMPHtGPb509kr5d26ddmiRJktSq2eBK+9GCNVu58v6Z/GXuGg7p04l7Pn8sxw/tmXZZkiRJUlGwwZX2g2076/nZ4/O545kFVJaVcsW5o/nUew6ivDQphUCSJElSrmxwpQKKMXL/6yu49oFZrNxcwz8dNYDLzxpJr87ZkwQlSVKB5Zh0nItc04wT5ZiWTGPC8rmuN8vySanIFRuzjze0z77SxoT/1F+/vFvW8foDSlm3/IDdxiu3J8xfkXDQoHePrMN13bNfqWJHz93n2dEr+zrrOya9UAnDCdsy530yafl8pR/nY/5c58gxOXxPbHClApm9cjMTJlfzwsL1HNq/C7d84iiOPmj3X9SSJEmS8sMGV8qzTTvquPHRufzm+cV0rizj2g8fxseOGUhp4rXPJEmSJOXDuza4IYRfAecCq2OMh2bGJgKfB9ZkFvtWjHFa5r5vAhcDDcBXYowPF6BuqcVpbIzc98oyfvDgbDZsr+XCYwfx1dNHcEDHirRLkyRJktqE5hzBvRO4Gbj7HeM3xhhv2HUghDAauAAYA/QDHgshHBJjTDrjXCoKry/byBWTq3lt6UaOPugA7jpvHIf275p2WZIkSVKb8q4NbozxqRDC4GbONx64N8a4E1gYQpgPjAOe2+sKpRZs/bZarn94Nve+tJQeHdvxo38+go8c1Z+Qc6qDJEmSpH21L5/B/VII4dPAy8BXY4wbgP7A87sssywztpsQwiXAJQCDBg3ahzKk/a+hMXLPC4u54ZG5bNtZz8UnDOGy04bTubI87dIkSdKe5CMJNmnxpKv/5ZqKnGtybFJqb0K6cklt0gOylFKWvZj6DtnnSFpnxabsy5dvy96OlHQKtF9emn2yLLb2zT5PQ7vsKc0NFdnryTbe0C77Nmhon9sLFeqyr7Mk6VzXpHTshPGk/S/n/Swfx2nylBy+N/b2Ipy3AUOBI4EVwI9ynSDGOCnGWBVjrOrVq9deliHtfy8tWs+5P3uG706u5tD+XXjwsvfynXNH29xKkiRJKdurI7gxxlV//z6E8EtgaubmcmDgLosOyIxJrd6qzTV8f9os/ve1t+nXtZJbLjyKsw870NORJUmSpBZirxrcEELfGOOKzM0PA29mvp8C3BNC+DFNIVPDgRf3uUopRbX1jdz514Xc9Ng86hoiXz5lGF88aSgdKrzKliRJktSSNOcyQb8HTgJ6hhCWAROAk0IIR9J0tvQi4F8BYozVIYQ/AjOBeuBSE5TVmj09bw0Tp1Tz1pptnDKyN1ecO5rBPTumXZYkSZKkLJqTovzxLMN37GH5a4Br9qUoKW3LNmzn6qmzeKh6JQf16MAdF1Vx6qg+aZclSZL2VR7DbJot4dNMMSnrKSmUKsdwoaT5SxLCjmLJ7itOmruhXfbxxHChpPE9BB01VjR/+W39s6+gpldCiNXOhPVmUb4tKRwq+3hjQjBXUu1J8yRJel2Jedq58/Hpu0IGWL0Lz7GUdlFT18CkpxZw65PzAfjaGSO4+MQhVJY3P8VPkiRJUjpscCUgxshjs1bzvakzWbJ+O+cc1pdvnTOK/t3ap12aJEmSpGaywVWbt3DtNq68v5on56xheO9O3PMvx3L8sJ5plyVJkiQpRza4arO219Zz8+Pzuf3phVSUlfCdc0Zx0fGDKS/d28tDS5IkSUqTDa7anBgjU19fwbXTZrFiUw3/dNQAvnHWCHp3rky7NEmSJEn7wAZXbcqclVuYMOVNnl+wnjH9unDzhWM5+qDuaZclSZL2l2wprrmGz+a6fMLJYUlpyUnzJ6XnxqQszMQ6k2Kak5Zv/jpDwgVCk8YTE6bJ/nwbKrPX3tgut+dUUpOQjFyXZYrGhNTp0vykFiemIudLrgnW+UhA3g9pyUlscNUmbK6p4yePzuOu5xbRubKMaz58KBccM4jSkhR/+iRJkiTllQ2uilpjY+R/XlnGDx6azbpttVw4bhD/9YERHNAx24XVJEmSJLVmNrgqWm8s28QVU97k1SUbOWpQN379mXEcNqBr2mVJkiRJKhAbXBWd9dtquf7hOdz70hJ6dGzHj/75CD48tj8lno4sSZIkFTUbXBWNhsbIPS8s5oZH5rJ1Zz2fO2EIl502nC6V5WmXJkmSJGk/sMFVUXh50XqumFzNzBWbec/BPbhy/BgO6dM57bIkSVK+5HoiVn4CbnOTa42NeVptC5onKV05cbwkKf040li++31Jm7g0IRU510TgmKU7igmTJKYfJ4wnpWbHmP2OXJOni9JePFcbXLVqqzfXcN2Ds/nTq8vp27WSmy8cyzmH9SWEtvSTL0mSJAlscNVK1TU0cuezi7hp+jxq6xv5t5OG8qVThtGhwl1akiRJaqvsBtTqPDt/LROmVDN/9VZOGdmbK84dzeCeHdMuS5IkSVLKbHDVaizfuINrHpjJtDdWMqh7B+64qIpTR/VJuyxJkiRJLYQNrlq8mroGfvnUAm55cj4A//WBQ/iX9x5MZXlCWoEkSZKkNskGVy1WjJHps1Zz1dSZLFm/nbMPO5BvnzOa/t3ap12aJEna33JNRU7Km8xHunK+Ep1znSfX55QcUNz8VTbmVmRjaULicFLXsadasq06X881KTE6l23T/EXzK9f9KV8/O2nYi59XG1y1SAvXbuOq+6t5Ys4ahvXuxG8vPpYTh/dMuyxJkiRJLZgNrlqU7bX13Pz4fG5/eiEVZSV855xRXHT8YMpLS9IuTZIkSVILZ4OrFiHGyNTXV3DttFms2FTDR8b25/KzRtK7S2XapUmSJElqJWxwlbo5K7cwYcqbPL9gPaP7duFnHx9L1eDuaZclSZIkqZV51wY3hPAr4FxgdYzx0MxYd+APwGBgEXB+jHFDCCEANwFnA9uBz8QYXylM6WrtNtfU8ZNH53HXc4vo1K6M733oUC4cN4jSkpb0yXZJkiRJrUVzjuDeCdwM3L3L2OXA9BjjdSGEyzO3vwGcBQzP/DsWuC3zVfo/jY2R/3llGT94aDbrttVywTGD+NoZI+jesSLt0iRJUtrylQSby/KFTFzeH/JUZ9bE5BwTe2Mer+IYsiUdFzAxummeLE8sYZJsi6aq0GnJ2eZPmiPFn6l3bXBjjE+FEAa/Y3g8cFLm+7uAJ2lqcMcDd8cYI/B8CKFbCKFvjHFFvgpW6/bGsk1cMeVNXl2ykbGDuvHrz4zjsAFd0y5LkiRJUhHY28/g9tmlaV0J9Ml83x9YustyyzJjNrht3IZttVz/yBx+/+ISenSs4PqPHs4/HTWAEk9HliRJkpQn+xwyFWOMIeR88J8QwiXAJQCDBg3a1zLUQjU0Rn7/4hJueGQOW2rq+dwJQ7jstOF0qSxPuzRJkiRJRWZvG9xVfz/1OITQF1idGV8ODNxluQGZsd3EGCcBkwCqqqpayycclIMZi9dzxeRqqt/ezHsO7sGV48dwSJ/OaZclSZIkqUjtbYM7BbgIuC7zdfIu418KIdxLU7jUJj9/2/as3lLDdQ/O5k+vLKdv10p+9vGxnHt4X5pCtiVJkiSpMJpzmaDf0xQo1TOEsAyYQFNj+8cQwsXAYuD8zOLTaLpE0HyaLhP02QLUrBaqrqGRu/66iJ88No/a+kb+7aShXHryMDq283LLkiSpmfKVBJvG+YGFriVP8ySm/2YLEE6aoyTHYvKWcpwwT7YE6D1JSkbO9rxKEkrJ07GbxG1Q6P0mx4TsnFKXUzw/tzkpyh9PuOvULMtG4NJ9LUqtz7Pz1zJhSjXzV2/lpBG9mPDBMQzp2THtsiRJkiS1IR5a0z55e+MOrnlgFg+8sYJB3Ttw+6erOHVUb09HliRJkrTf2eBqr9TUNXD70wu45Ym3iES+evohfP59B1NZnsere0uSJElSDmxwlbPHZ6/iyvtnsnjdds469EC+fc4oBhzQIe2yJEmSJLVxNrhqtkVrt/G9qTOZPns1Q3t15DcXj+O9w3ulXZYkSZIkATa4aobttfXc+sRbTHpqAeWlgW+dPZLPHD+EirKESDlJkqR8y1e8R7Z5WljKcUuSlJaclCCccyLwnrZZYw7zJ6Ui57rf5LB8odOPQ5bnD7mlYO9R0lv5Vr4f2+AqUYyRB99cydVTZ/L2pho+PLY/3zxrJL27VKZdmiRJkiTtxgZXWc1btYWJ91fz7Px1jOrbhZ9cMJZxQ7qnXZYkSZIkJbLB1T/YUlPHT6fP49fPLqJDRSnfGz+Gj48bRFmppyNLkiRJatlscAU0nY78v68t59pps1m7dScfqxrI184YQY9O7dIuTZIkSZKaxQZXVL+9iQmTq3l58QaOGNiNX366iiMHdku7LEmSJEnKiQ1uG7Zxey0/emQuv3thMd06VPDDfzqcjx49gJKSfMUUSpIk5UlbSjpOTArer1XsWa61JDynxCTipGlyTRBOmj+XBOGENOMkuT6n1ORaZ7blW9I+mWGD2wY1NEb++PJSfvjQbDbtqONTxx3Ef54+gq4dytMuTZIkSZL2mg1uG/Pqkg1MmFLN68s2MW5wd64cP4ZRfbukXZYkSZIk7TMb3DZi7dad/PCh2fzx5WX07tyOmy44kvOO6EcILfC8AkmSJEnaCza4Ra6+oZHfPr+YHz06lx21DVzyvoP5yqnD6dTOl16SJElScbHLKWIvLFjHhCnVzF65hROH9WTieWMY1rtT2mVJkiRJUkHY4BahlZtquHbaLKb87W36d2vPzz95FGeMOdDTkSVJUtuRa6puS5LWW7Z8xP/mKxUZctsOub7eeXiqiZsr6UnluH1zToxOkq/9qZW0Eja4RaS2vpFfP7uQn06fR11j5CunDOOLJw2jfUVp2qVJkiRJUsHZ4BaJp+auYeL91SxYs43TRvXhinNHM6hHh7TLkiRJkqT9xga3lVu2YTtXT53FQ9UrGdyjA7/+zDGcPLJ32mVJkiRJ0n5ng9tK1dQ1MOmpBdzyxHxKQuBrZ4zgX947hHZlno4sSZIkqW2ywW1lYoxMn7Waq6bOZMn67ZxzWF++fc4o+nVrn3ZpkiRJkpSqfWpwQwiLgC1AA1AfY6wKIXQH/gAMBhYB58cYN+xbmQJYuHYbV91fzRNz1jC8dyfu+ZdjOX5Yz7TLkiRJanlac1pyUu0pJEPvMeW4Jcl1G+S6jbNNkZhynKcXJK1tn4dtk7M87tv5OIJ7coxx7S63LwemxxivCyFcnrn9jTysp83aXlvPLU/M55dPLaSirITvnDOKi44fTHlpSdqlSZIkSVKLUYhTlMcDJ2W+vwt4EhvcvRJj5ME3V3L11Jm8vamGj4ztz+VnjaR3l8q0S5MkSZKkFmdfG9wIPBJCiMAvYoyTgD4xxhWZ+1cCffZxHW3S/NVbmDClmmfnr2NU3y7c9PGxHDO4e9plSZIkSVKLta8N7okxxuUhhN7AoyGE2bveGWOMmeZ3NyGES4BLAAYNGrSPZRSPLTV1/HT6PH797CI6VJRy1fgxXDhuEGWejixJkiRJe7RPDW6McXnm6+oQwp+BccCqEELfGOOKEEJfYHXCYycBkwCqqqpaQwxAQcUYmfza21w7bRZrtu7kY1UD+doZI+jRqV3apUmSJElSq7DXDW4IoSNQEmPckvn+A8BVwBTgIuC6zNfJ+Si0mM18ezMTp1Tz4qL1HDGgK5M+XcWRA7ulXZYkSVLLV8hk4XzNna958rXeXKbPV3JuoROBC7ltcq09jRTifMpHnbnu83k83LkvR3D7AH8OIfx9nntijA+FEF4C/hhCuBhYDJy/72UWp03b6/jxo3P4zfOL6dahgus+chjnVw2kpKS17P2SJEmS1HLsdYMbY1wAHJFlfB1w6r4UVewaGyP3zVjGDx6azYbttXzyuIP4z9MPoVuHirRLkyRJkqRWqxCXCdIevL5sI9+dXM3flm6k6qADuHv8OMb065p2WZIkSZLU6tng7icbttXyw4fncO9LS+jRsR0/Pv8IPjy2P5lTvCVJkiRJ+8gGt8AaGiO/f3EJNzwyhy019Vx8whAuO204nSvL0y5NkiRJkoqKDW4BvbJkA1dMfpM3l2/muIO7c9X4QzmkT+e0y5IkSSoexXixyVwTaFvzCYH5ev0Kmaadq9b8euRLij+XNrgFsHbrTn7w4Gz+e8Yy+nRpx08/PpYPHt7X05ElSZIkqYBscPOooTHyuxcWc8PDc9he28C/vu9gvnzqcDq1czNLkiRJUqHZeeXJjMXr+e7/VjNzxWZOGNaDK88bw7Deno4sSZIkSfuLDe4+Wrt1J9c9OJv7ZizjwC6V3HLhUZx92IGejixJkiRJ+5kN7l6qb2jkt88v5kePzqWmroEvvH8oXz5lGB09HVmSJKltylfQUb4CenINpUrj+Eyh1+kxpzbHbmwvvLRoPVdMrmbWis2cOKwnE88bw7DendIuS5IkSZLaNBvcHKzeUsN102bzp1eX069rJbd+4ijOOtTTkSVJkiSpJbDBbYa6hkZ+89xibnx0LjX1DfzbSUP50inD6FDh5pMkSZKklsIO7V389a21TJxSzdxVW3nfIb2Y+MHRHNzL05ElSZIkqaWxwU2wYtMOrnlgFlNfX8GAA9oz6VNHc/roPp6OLEmSJEktlA3uO+ysb+D2pxdy8+PzaYyRfz9tOF94/1Aqy0vTLk2SJKn45SuJOB8KnX5c6OfqcZl05Lrd09i3i5gN7i6emL2aK++vZtG67XxgdB++e+5oBnbvkHZZkiRJkqRmsMEFlqzbzpX3VzN99moO7tmRuz43jvcf0ivtsiRJkiRJOWjTDW5NXQO3PfkWt/3lLcpLAt88aySfPWEIFWUlaZcmSZIkScpRm21wH5u5iiunVrN0/Q7OO6If3zp7FAd2rUy7LEmSJEnSXmpzDe7yjTuYMLmax2atYljvTtzz+WM5fmjPtMuSJEmSJO2jNtPg1jc0cudfF/HjR+cSI1x+1kguPnEI5aWejixJktRitKVE2bb0XOXrvZ+0iQb3zeWb+Mb/vE7125s5eUQvrhp/qOnIkiRJklRkCtbghhDOBG4CSoHbY4zXFWpdSWKM/Pb5xXxv6iy6dijnlguP4uzDDiQELwomSZIkScWmIA1uCKEUuAU4HVgGvBRCmBJjnFmI9WWzpaaOy//0Bg+8voKTR/TiR+cfSfeOFftr9ZIkSZKk/axQR3DHAfNjjAsAQgj3AuOB/dLgvrl8E5fe8wrLNuzgG2eO5F/fdzAlJR61lSRJkqRiVqgGtz+wdJfby4BjC7Suf9DQGPnK719lZ10j915yHMcM7r4/VitJkiRJSllqIVMhhEuASwAGDRqUt3lLSwK3fvIoenVqR49O7fI2ryRJkrRXkk4kLMZU3aTnlLQNivEky9byurak/TLX/WYPCnWNnOXAwF1uD8iM/Z8Y46QYY1WMsapXr155XfnIA7vY3EqSJElSG1OoBvclYHgIYUgIoQK4AJhSoHVJkiRJklSYU5RjjPUhhC8BD9N0maBfxRirC7EuSZIkSZKggJ/BjTFOA6YVan5JkiRJknZVqFOUJUmSJEnar1JLUZYkSZKKSktKpS20fD3XfG2bXOvJZfk8Jvy2KC1pv8zjtvQIriRJkiSpKNjgSpIkSZKKgg2uJEmSJKko2OBKkiRJkoqCDa4kSZIkqSiEGNOPzwohrAEW53nansDaPM/ZVrkt88dtmT9uy/xxW+ZPIbblQTHGXnmeU0pdgd7/qXj4t0l7kvi3sUU0uIUQQng5xliVdh3FwG2ZP27L/HFb5o/bMn/clpKUH/4+1d7yFGVJkiRJUlGwwZUkSZIkFYVibnAnpV1AEXFb5o/bMn/clvnjtswft6Uk5Ye/T7VXivYzuJIkSZKktqWYj+BKkiRJktqQomtwQwhnhhDmhBDmhxAuT7ue1iSEMDCE8EQIYWYIoTqEcFlmvHsI4dEQwrzM1wPSrrW1CCGUhhBeDSFMzdweEkJ4IbN//iGEUJF2ja1BCKFbCOG+EMLsEMKsEMJ73C/3TgjhPzI/32+GEH4fQqh0v2y+EMKvQgirQwhv7jKWdV8MTX6a2a6vhxCOSq9ySWoZ9vB+8/rM3/nXQwh/DiF0S3j8ohDCGyGE10IIL+/f6tUaFFWDG0IoBW4BzgJGAx8PIYxOt6pWpR74aoxxNHAccGlm+10OTI8xDgemZ26reS4DZu1y+wfAjTHGYcAG4OJUqmp9bgIeijGOBI6gaZu6X+YohNAf+ApQFWM8FCgFLsD9Mhd3Ame+YyxpXzwLGJ75dwlw236qUZJasqT3m48Ch8YYDwfmAt/cwxwnxxiP9DJCyqaoGlxgHDA/xrggxlgL3AuMT7mmViPGuCLG+Erm+y00NRH9adqGd2UWuwv4UDoVti4hhAHAOcDtmdsBOAW4L7OI27IZQghdgfcBdwDEGGtjjBtxv9xbZUD7EEIZ0AFYgftls8UYnwLWv2M4aV8cD9wdmzwPdAsh9N0/lUpSy5T0fjPG+EiMsT6z2PPAgLRqVOtWbA1uf2DpLreXZcaUoxDCYGAs8ALQJ8a4InPXSqBPSmW1Nj8Bvg40Zm73ADbu8svb/bN5hgBrgF9nTve+PYTQEffLnMUYlwM3AEtoamw3ATNwv9xXSfuif5MkaQ/e8X5zV58DHkx4WAQeCSHMCCFcUrjq1FoVW4OrPAghdAL+B/j3GOPmXe+LTbHbRm+/ixDCucDqGOOMtGspAmXAUcBtMcaxwDbecTqy+2XzZD4bOp6m/zToB3Rk99NttQ/cFyWpeZLeb4YQvk3Tacy/S3joiTHGo2j6GMilIYT3FbxYtSrF1uAuBwbucntAZkzNFEIop+mXze9ijH/KDK/6+2l1ma+r06qvFTkBOC+EsIimU+VPoelzpN0yp4aC+2dzLQOWxRj//r+799HU8Lpf5u40YGGMcU2MsQ74E037qvvlvknaF/2bJElZJLzfJITwGeBc4BMx4VqmmbORiDGuBv5M00cUpf9TbA3uS8DwTCJoBU3hKVNSrqnVyHxG9A5gVozxx7vcNQW4KPP9RcDk/V1baxNj/GaMcUCMcTBN++HjMcZPAE8AH80s5rZshhjjSmBpCGFEZuhUYCbul3tjCXBcCKFD5uf979vS/XLfJO2LU4BPZ9KUjwM27XIqsyS1SUnvN0MIZ9L00a7z4v9r735VIoiiOI5/D4oGsYjJYPAJfADDJsNi1mJZMPgAJosYfAHZKEYFi76DxbZBs2A0WBdMx3BHhGVHNC175/tJw/yBCTec35177mSOW55diYjV72NgF3iZdq+6K1omR+ZWRPQpvY8LwHVmXsz4leZGROwAj8AzP32jp5S+iDtgE3gD9jNzcpMVtYiIHnCSmXsRsUX5orsGjIDDzPyc5fvNg4jYpmzWtQS8AgPKBJ3j8p8i4hw4oCz/GgFHQigJTAAAAJRJREFUlL5Qx+UfRMQt0APWgXfgDHhgylhsirghZRn4GBhkpr+0kNRpv9Sbl8Ay8NGce8rM44jYAK4ys9/UUffN9UXgxlpfk6oLuJIkSZKkbqptibIkSZIkqaMMuJIkSZKkKhhwJUmSJElVMOBKkiRJkqpgwJUkSZIkVcGAK0mSJEmqggFXkiRJklQFA64kSZIkqQpf55dr03F0MyUAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 1296x360 with 2 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "fig, axes = plt.subplots(1, 2, figsize=(18, 5))\n",
-    "axes[0].plot(fevals)\n",
-    "axes[1].imshow(opt_x.squeeze().detach().cpu().numpy())\n",
-    "axes[1].grid()\n",
-    "axes[1].set_yticks([opt_x.squeeze().shape[0] / 2 -0.5])\n",
-    "axes[1].set_xticks([opt_x.squeeze().shape[1] / 2 -0.5])"
    ]
   },
   {


### PR DESCRIPTION
It just doesn't work as expected. In an ensemble any use of it will create entirely wrong MEIs. It will work when using a single model but (0, 0) still won't be in the center of the screen so it's not that useful anyway. I think it will just confuse people and cause wrong results in the future